### PR TITLE
Bugfixes

### DIFF
--- a/ssh_autocomp.bash
+++ b/ssh_autocomp.bash
@@ -9,6 +9,13 @@ HEURISTIC="most" # "" "last" "most"
 HEURISTIC_CACHE_LNC=~/.ssh_last_n
 HEURISTIC_CACHE_MC=~/.ssh_most
 
+#
+# UTILITY FUNCTIONS
+#
+dbgecho() {
+    # Comment these out to disable printing debug messages:
+    [ -f "./debug.log" ] && echo "$@" >> "debug.log"
+}
 
 # Compatibility mode:
 OUTPUT_WITHOUT_ATPREFIX=false
@@ -20,12 +27,6 @@ fi
 #
 # UTILITY FUNCTIONS
 #
-
-dbgecho() {
-    # Comment these out to disable printing debug messages:
-    [ -f "./debug.log" ] && echo "$@" >> "debug.log"
-}
-
 
 function firstcmd() {
     for ALTERNATIVE in "$@"; do

--- a/ssh_autocomp.bash
+++ b/ssh_autocomp.bash
@@ -221,7 +221,7 @@ function _ssh() {
         *)  LAST_USER="";; # Otherwise, we don't know <user>
     esac
 
-    HOSTS=$(grep '^Host' $SSH_CONFIG_PATHS 2>/dev/null | grep -v '[?*]' | cut -d ' ' -f 2-)
+    HOSTS=$(grep -i '^Host' $SSH_CONFIG_PATHS 2>/dev/null | grep -v '[?*]' | cut -d ' ' -f 2-)
 
     local TARGETS
     TARGETS=( $(compgen -W "$HOSTS" -- $LAST_SERVER) )


### PR DESCRIPTION
Allow "host" as opposed to just "Host" in ssh config file. Move dbgecho definition up to fix "dbgecho not defined" error

